### PR TITLE
fix!: do not pull cli defaults from the top level default key

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opta",
-  "version": "0.0.7",
+  "version": "0.0.7-flag-defaults.0",
   "description": "Collect user input from cli flags, interactive prompts, and js input.",
   "main": "index.js",
   "type": "commonjs",


### PR DESCRIPTION
One common issue I have been running into, when you set a `default` it passes that into the `yargs` config, which then results in thinking that is user `input`, so it will override any other default behaviors.  This is unexpected to me, and it has meant that I often have set `defaultDescription` for the yargs settings and then had the actual `.defaults()` call set the default in my program logic.

Thoughts?

cc @boneskull