### PR TITLE
feat(deps)!:yargs@17

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "inquirer": "^7.1.0",
-    "yargs": "^16.1.0"
+    "yargs": "^17.3.1"
   },
   "devDependencies": {
     "mocha": "^7.1.2",


### PR DESCRIPTION
Updated yargs, since we directly expose yargs api this is breaking.