### PR TITLE
fix(utils): fixed prompt utils when using when/default

### DIFF
--- a/test/util.js
+++ b/test/util.js
@@ -6,6 +6,8 @@ const utils = require('../utils')
 suite('utils', () => {
   suite('promptModule', async () => {
     test('take options and run assertions and return output', async () => {
+      let calledWhen = false
+      let calledDefault = false
       const prompts = [{
         name: 'example',
         message: 'example:',
@@ -16,10 +18,42 @@ suite('utils', () => {
         message: 'example two:',
         type: 'input',
         when: false
+      }, {
+        name: 'example3',
+        message: 'example three:',
+        type: 'input',
+        when: (answers, whenDefault, allInput) => {
+          calledWhen = true
+          assert.strictEqual(answers.example, 'test input')
+          assert.strictEqual(answers.example2, undefined)
+          assert.strictEqual(answers.additionalInput, undefined)
+          assert.strictEqual(whenDefault, true)
+          assert.strictEqual(allInput.additionalInput, 'input')
+          return false
+        }
+      }, {
+        name: 'example4',
+        message: 'example four:',
+        type: 'input',
+        when: (answers, whenDefault, allInput) => {
+          assert.strictEqual(whenDefault, false)
+          return false
+        }
+      }, {
+        name: 'example5',
+        message: 'example five:',
+        type: 'input',
+        default: (answers, allInput) => {
+          calledDefault = true
+          assert.strictEqual(answers.example, 'test input')
+          assert.strictEqual(answers.additionalInput, undefined)
+          assert.strictEqual(allInput.additionalInput, 'input')
+          return 'example5 default'
+        }
       }]
 
       const pm = utils.test.promptModule({
-        assertCount: 1,
+        assertCount: 2,
         prompts: {
           example: 'test input',
           example2: {
@@ -27,14 +61,30 @@ suite('utils', () => {
             assert: (p) => {
               assert.deepStrictEqual(p, prompts[1])
             }
+          },
+          example3: {
+            whenContext: {
+              additionalInput: 'input'
+            }
+          },
+          example4: {
+            whenDefault: false
+          },
+          example5: {
+            defaultContext: {
+              additionalInput: 'input'
+            }
           }
         }
       })()
 
       const output = await pm(prompts)
 
+      assert(calledWhen, 'example3 when not called')
+      assert(calledDefault, 'example5 default not called')
       assert.deepStrictEqual(output, {
-        example: 'test input'
+        example: 'test input',
+        example5: 'example5 default'
       })
     })
   })


### PR DESCRIPTION
Previously the behavior of `.when` and `.default` in the test utils did not correctly mimic the real behavior:

- `.when()` was unsupported (only supported boolean), now becomes `.when(answers, defaultWhenValue, allInput)`
- `.default(allInput)` becomes `.default(answers, allInput)`

The original `.default` uses `defaultContext` for setting `allInput` so I added `whenContext` and `whenDefault` for those. This can probably be consolidated in the future to just `context` for both.