### PR TITLE
fix(utils): call assert on prompt even when when is false

### DIFF
--- a/test/util.js
+++ b/test/util.js
@@ -87,5 +87,52 @@ suite('utils', () => {
         example5: 'example5 default'
       })
     })
+
+    test('always calls prompt assertions even if when false', async () => {
+      let called = 0
+      function calledAssert (p) {
+        called++
+        return true
+      }
+      const prompts = [{
+        name: 'example',
+        when: true
+      }, {
+        name: 'example2',
+        when: false
+      }, {
+        name: 'example3',
+        when: () => {
+          return false
+        }
+      }, {
+        name: 'example4',
+        when: () => {
+          return true
+        }
+      }]
+
+      const pm = utils.test.promptModule({
+        assertCount: 2,
+        prompts: {
+          example: {
+            assert: calledAssert
+          },
+          example2: {
+            assert: calledAssert
+          },
+          example3: {
+            assert: calledAssert
+          },
+          example4: {
+            assert: calledAssert
+          }
+        }
+      })()
+
+      await pm(prompts)
+
+      assert.strictEqual(called, 4)
+    })
   })
 })

--- a/utils.js
+++ b/utils.js
@@ -76,6 +76,9 @@ function promptModule (opts = {}) {
 
         // If when is false, dont "ask" or set a return
         if (p.when === false) {
+          if (promptOpts.assert) {
+            promptOpts.assert(p)
+          }
           return []
         }
         if (typeof p.when === 'function') {
@@ -86,6 +89,9 @@ function promptModule (opts = {}) {
             whenRet = await whenRet
           }
           if (!whenRet) {
+            if (promptOpts.assert) {
+              promptOpts.assert(p)
+            }
             return []
           }
         }


### PR DESCRIPTION
Previously assertions on `when: false` prompts in the test util would early exit and not allow testing of the prompt config. This allows assertions to be added even on prompts that would not show.